### PR TITLE
Replace watch command with builtin shell loop.

### DIFF
--- a/watch-stats.sh
+++ b/watch-stats.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-watch 'echo "show stat" | nc -U /var/lib/haproxy/stats | cut -d "," -f 1,2,18,57| column -s, -t'
+while true; do printf "\033c"; echo "show stat" | nc -U /var/lib/haproxy/stats | cut -d "," -f 1,2,18,57| column -s, -t; sleep 2; done


### PR DESCRIPTION
This PR was caused by the missing watch binary file in the current image, which breaks the watch-stats.sh file.

The usage of shell builtin while and printf guarantees more compatibility.

The script was kept minimal as the original.