### PR TITLE
Added configuration capability for the server & client timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenShift 4 load balancer for PoC's or developemt/testing purpose - NOT for prod
 
 ![build status](https://quay.io/repository/redhat-emea-ssa-team/openshift-4-loadbalancer/status)
 
-If you like to play with it and look around: 
+If you like to play with it and look around:
 ```
 podman run -ti quay.io/redhat-emea-ssa-team/openshift-4-loadbalancer bash
 $ haproxy -f /haproxy.cfg
@@ -26,13 +26,15 @@ $ haproxy -f /haproxy.cfg
 |MACHINE_CONFIG_SERVER_LISTEN|Machine config server listener|`127.0.0.1:22623,192.168.222.1:22623`
 |STATS_LISTEN|Stats listen if empty stats on TCP socket is disabled|`127.0.0.1:1984`
 |STATS_ADMIN_PASSWORD|Stats admin passwort if empty stats on TCP socket is disabled|`aengeo4oodoidaiP`
+|HAPROXY_CLIENT_TIMEOUT|Client timeout for the connection. Defaults to 1m if not specified|`1m`
+|HAPROXY_SERVER_TIMEOUT|Server timeout for the connection. Defaults to 1m if not specified|`1m`
 
 ## Show stats via unix socket
 
 ```
 podman exec -ti openshift-4-loadbalancer /watch-stats.sh
 ```
-## Deployment 
+## Deployment
 
 ### Systemd service example
 
@@ -60,6 +62,8 @@ ExecStart=/usr/bin/podman run --name openshift-4-loadbalancer --net host \
   -e MACHINE_CONFIG_SERVER_LISTEN=127.0.0.1:22623,192.168.222.1:22623 \
   -e STATS_LISTEN=127.0.0.1:1984 \
   -e STATS_ADMIN_PASSWORD=aengeo4oodoidaiP \
+  -e HAPROXY_CLIENT_TIMEOUT=1m \
+  -e HAPROXY_SERVER_TIMEOUT=1m \
   quay.io/redhat-emea-ssa-team/openshift-4-loadbalancer
 
 ExecReload=-/usr/bin/podman stop "openshift-4-loadbalancer"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 # Examples:
+#   export HAPROXY_CLIENT_TIMEOUT=30s
+#   export HAPROXY_SERVER_TIMEOUT=30s
 #   export API="bootstrap=192.168.222.30:6443,master-0=192.168.222.31:6443,master-1=192.168.222.32:6443,master-3=192.168.222.33:6443"
 #   export API_LISTEN="127.0.0.1:6443,192.168.222.1:6443"
 #   export INGRESS_HTTP="master-0=192.168.222.31:80,master-1=192.168.222.32:80,master-3=192.168.222.33:80,worker-0=192.168.222.34:80,worker-1=192.168.222.35:80,worker-3=192.168.222.36:80"
@@ -18,8 +20,8 @@ function build_member_conf {
     DATA=$1
     IFS=,
     CONFIG=""
-    for i in $DATA ; do 
-        # i contains 'name=ip:port'        
+    for i in $DATA ; do
+        # i contains 'name=ip:port'
         #       ${i%:=} => name
         #       ${i#*=} => ip:port
         CONFIG+="    server ${i%=*} ${i#*=} check\n"
@@ -59,6 +61,10 @@ frontend stats
 else
     export STATS_CFG=""
 fi
+
+# If timeout valies are not set keep default to 1minute to maintain upward compatibility
+export HAPROXY_CLIENT_TIMEOUT_CFG=${HAPROXY_CLIENT_TIMEOUT:-1m}
+export HAPROXY_SERVER_TIMEOUT_CFG=${HAPROXY_SERVER_TIMEOUT:-1m}
 
 export INGRESS_HTTP_CFG=$(build_member_conf $INGRESS_HTTP)
 export INGRESS_HTTP_LISTEN_CFG=$(build_listen_conf ${INGRESS_HTTP_LISTEN:-*:80})

--- a/haproxy-template.cfg
+++ b/haproxy-template.cfg
@@ -30,8 +30,8 @@ defaults
     timeout http-request    10s
     timeout queue           1m
     timeout connect         10s
-    timeout client          1m
-    timeout server          1m
+    timeout client          $HAPROXY_CLIENT_TIMEOUT_CFG
+    timeout server          $HAPROXY_SERVER_TIMEOUT_CFG
     timeout http-keep-alive 10s
     timeout check           10s
     maxconn                 3000


### PR DESCRIPTION
The default `timeout server` and `timeout client` settings in the haproxy.cfg could not be configured so far. Using this pull-request these configuration settings can be set by setting the following environment variables when starting the container:

- HAPROXY_CLIENT_TIMEOUT
- HAPROXY_SERVER_TIMEOUT

to the desired timeout values. The values for the environment variables must comply with the HAPROXY documentation (https://cbonte.github.io/haproxy-dconv/1.7/configuration.html)